### PR TITLE
Use unique message titles

### DIFF
--- a/messages/outlet-notify-request.json
+++ b/messages/outlet-notify-request.json
@@ -56,7 +56,7 @@
         },
         "message": {
           "type": "string",
-          "title": "Message",
+          "title": "Notification message",
           "description": "Message of the notification"
         },
         "level": {

--- a/messages/plugin-error-notification.json
+++ b/messages/plugin-error-notification.json
@@ -31,7 +31,7 @@
         },
         "message": {
           "type": "string",
-          "title": "Message",
+          "title": "Error message",
           "description": "Error message"
         }
       }


### PR DESCRIPTION
This should eliminate the `Message2` interface.
https://github.com/WebThingsIO/gateway-addon-node/pull/55#discussion_r520336031