### PR TITLE
W3C compliance - Use forms instead of links in Properties, Actions, and Events

### DIFF
--- a/messages/definitions.json
+++ b/messages/definitions.json
@@ -329,10 +329,10 @@
           "title": "Action Description",
           "description": "Description of the Action"
         },
-        "links": {
+        "forms": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/link"
+            "$ref": "#/definitions/form_element_action"
           }
         },
         "input": {

--- a/messages/definitions.json
+++ b/messages/definitions.json
@@ -180,7 +180,8 @@
       "title": "Property",
       "description": "Description of the Property",
       "required": [
-        "type"
+        "type",
+        "forms"
       ],
       "properties": {
         "@type": {
@@ -203,10 +204,10 @@
           "title": "Property Description",
           "description": "Description of the property"
         },
-        "links": {
+        "forms": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/link"
+            "$ref": "#/definitions/form_element_property"
           }
         },
         "type": {
@@ -504,6 +505,203 @@
           }
         }
       }
+    },
+    "anyUri": {
+      "type": "string"
+    },
+    "security": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "scopes": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "form_element":{
+      "title": "Form",
+      "type":"object",
+      "properties": {
+        "href": {
+          "$ref": "#/definitions/anyUri"
+        },
+        "contentType": {
+          "type": "string"
+        },
+        "contentCoding": {
+          "type": "string"
+        },
+        "subprotocol": {
+          "type": "string"
+        },
+        "security": {
+          "$ref": "#/definitions/security"
+        },
+        "scopes": {
+          "$ref": "#/definitions/scopes"
+        },
+        "response": {
+          "type": "object",
+          "properties": {
+            "contentType": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "required": [
+        "href"
+      ]
+    },
+    "form_element_property": {
+      "title": "PropertyForm",
+      "allOf":[
+        { "$ref": "#/definitions/form_element" },
+        {
+          "properties": {
+            "op": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "readproperty",
+                    "writeproperty",
+                    "observeproperty",
+                    "unobserveproperty"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "readproperty",
+                      "writeproperty",
+                      "observeproperty",
+                      "unobserveproperty"
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "form_element_action": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/form_element"
+        },
+        {
+          "properties": {
+            "op": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "invokeaction"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "invokeaction"
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "form_element_event": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/form_element"
+        },
+        {
+          "properties": {
+            "op": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "subscribeevent",
+                    "unsubscribeevent"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "subscribeevent",
+                      "unsubscribeevent"
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "form_element_root": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/form_element"
+        },
+        {
+          "properties": {
+            "op": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "readallproperties",
+                    "writeallproperties",
+                    "readmultipleproperties",
+                    "writemultipleproperties"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "readallproperties",
+                      "writeallproperties",
+                      "readmultipleproperties",
+                      "writemultipleproperties"
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/messages/definitions.json
+++ b/messages/definitions.json
@@ -180,8 +180,7 @@
       "title": "Property",
       "description": "Description of the Property",
       "required": [
-        "type",
-        "forms"
+        "type"
       ],
       "properties": {
         "@type": {

--- a/messages/definitions.json
+++ b/messages/definitions.json
@@ -455,10 +455,10 @@
           "title": "Event Description",
           "description": "Description of the event"
         },
-        "links": {
+        "forms": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/link"
+            "$ref": "#/definitions/form_element_event"
           }
         },
         "type": {


### PR DESCRIPTION
Hello, this is one of the first steps to achieve compliance with the current [W3C Thing Description specification](https://www.w3.org/TR/wot-thing-description/#json-schema-for-validation). This PR renames links to forms in property, actions, and events JSON schemas. 

See https://github.com/WebThingsIO/gateway/issues/2806 for context and rationale.

One comment, in the long run, it might be more convenient to use directly the JSON schema published by the w3c so that we don't need to manually copy over the changes between versions. However, I think that during this transition phase we could incrementally update the schemas here. 