### PR TITLE
Re-introduce the visible member of properties for the 1.1 release

### DIFF
--- a/messages/definitions.json
+++ b/messages/definitions.json
@@ -256,6 +256,11 @@
           "title": "Property read-only",
           "description": "If the property is read-only"
         },
+        "visible": {
+          "type": "boolean",
+          "title": "Property visible",
+          "description": "If the property is visible"
+        },
         "value": {
           "$ref": "definitions.json#/definitions/any",
           "title": "Property value",

--- a/messages/definitions.json
+++ b/messages/definitions.json
@@ -191,7 +191,8 @@
         "name": {
           "type": "string",
           "title": "Property name",
-          "description": "The name of the property"
+          "description": "The name of the property",
+          "deprecated": true
         },
         "title": {
           "type": "string",
@@ -259,12 +260,14 @@
         "visible": {
           "type": "boolean",
           "title": "Property visible",
-          "description": "If the property is visible"
+          "description": "If the property is visible",
+          "deprecated": true
         },
         "value": {
           "$ref": "definitions.json#/definitions/any",
           "title": "Property value",
-          "description": "The value of the property"
+          "description": "The value of the property",
+          "deprecated": true
         }
       }
     },
@@ -448,7 +451,8 @@
         "name": {
           "type": "string",
           "title": "Event name",
-          "description": "The name of the event"
+          "description": "The name of the event",
+          "deprecated": true
         },
         "title": {
           "type": "string",


### PR DESCRIPTION
This PR re-introduces support for the visible member of properties, which was removed shortly after the 1.0 release but is still being used by many add-ons.

This is the first part of a fix for https://github.com/WebThingsIO/gateway/issues/3038

I've created a new v1.1.X branch to branch off from master where all the breaking W3C compliance changes are happening and where this feature will continue to be removed entirely.

Note that I've also marked another couple of non-standard members (`name` and `value`) as deprecated, these are other members which I'd like to remove in a future release.

